### PR TITLE
NVIDIA driver tweakfuncs

### DIFF
--- a/modules/Windows/Invoke-NVIDIADriver.ps1
+++ b/modules/Windows/Invoke-NVIDIADriver.ps1
@@ -1,4 +1,4 @@
-function Get-Driver {
+function Get-NVIDIADriver {
     <#
         .SYNOPSIS
         Get all available driver versions.
@@ -29,7 +29,7 @@ function Get-Driver {
     else {return $GameReadyVersions}
 }
 
-function Invoke-Driver {
+function Invoke-NVIDIADriver {
     <#
         .SYNOPSIS
         Download an NVIDIA driver package.
@@ -50,8 +50,8 @@ function Invoke-Driver {
                     "setup.cfg", 
                     "setup.exe") -join " "
     if ($Version.ToLower() -eq 'latest') {
-        if ($Studio.IsPresent -eq $true) {$Version = (Get-Driver -Studio)[0]}
-        else {$Version = (Get-Driver)[0]}
+        if ($Studio.IsPresent -eq $true) {$Version = (Get-NVIDIADriver -Studio)[0]}
+        else {$Version = (Get-NVIDIADriver)[0]}
     } 
     if ($Studio.IsPresent -eq $True) {
         $Type = "Studio"

--- a/modules/Windows/Invoke-NVIDIADriver.ps1
+++ b/modules/Windows/Invoke-NVIDIADriver.ps1
@@ -1,3 +1,6 @@
+#Made by Aetopia.
+# Ported NVIDIA Driver Downloader Functions: https://github.com/Aetopia/NVIDIA-Driver-Downloader/blob/main/nvddl.py
+
 function Get-NVIDIADriver {
     <#
         .SYNOPSIS
@@ -76,7 +79,7 @@ function Invoke-NVIDIADriver {
             else {
                 Write-Output "Unpacking driver package with minimal components..."
                 Invoke-Expression """$7Zip"" x -bso0 -bsp1 -bse1 -aoa ""$env:TEMP/$Type - $Version.exe"" $Components -o""$env:TEMP/$Type - $Version"""
-                Write-Output "Unpacked $Type - $Version!"
+                Write-Output "Unpacked ($Type - $Version)!"
                 Start-Process "$env:TEMP/$Type - $Version/setup.exe" -ErrorAction 'silentlycontinue'
             }
         }

--- a/modules/Windows/NVIDIA.ps1
+++ b/modules/Windows/NVIDIA.ps1
@@ -58,7 +58,7 @@ function Invoke-Driver {
         $DriverLink = "https://international.download.nvidia.com/Windows/$Version/$Version-desktop-win10-win11-64bit-international-nsd-dch-whql.exe" 
     }
     else {
-        $Type = "Studio"
+        $Type = "Game Ready"
         $DriverLink = "https://international.download.nvidia.com/Windows/$Version/$Version-desktop-win10-win11-64bit-international-dch-whql.exe"
     }    
     Write-Output "Checking Download..."

--- a/modules/Windows/NVIDIA.ps1
+++ b/modules/Windows/NVIDIA.ps1
@@ -1,0 +1,86 @@
+function Get-Driver {
+    <#
+        .SYNOPSIS
+        Get all available driver versions.
+    #>
+    param (
+        [switch]$Studio
+    )
+    $GameReadyVersions = @()
+    $File = (Invoke-WebRequest 'https://www.nvidia.com/Download/processFind.aspx?psid=101&pfid=845&osid=57&lid=1&whql=1&ctk=0&dtcid=1').RawContent
+    foreach ($Line in $File.Split('`n')){
+        if ($Line -match "<td class=""gridItem"">*.*</td>") {
+            $Version = $Line.Split('>')[5].Split('<')[0]
+            $GameReadyVersions += $Version 
+        }
+    }
+    if ($Studio.IsPresent -eq $true) {
+        $StudioVersions = @()
+        foreach ($Version in $GameReadyVersions) {
+            try {
+                $DriverLink = "https://international.download.nvidia.com/Windows/$Version/$Version-desktop-win10-win11-64bit-international-nsd-dch-whql.exe"
+                $StatusCode = (Invoke-WebRequest -Uri "$DriverLink" -DisableKeepAlive -Method Head).StatusCode
+                if ($StatusCode -eq 200){$StudioVersions += $Version}
+            }
+            catch {}
+        }
+        return $StudioVersions
+    }
+    else {return $GameReadyVersions}
+}
+
+function Invoke-Driver {
+    <#
+        .SYNOPSIS
+        Download an NVIDIA driver package.
+    #>
+    param (
+        [string]$Version = 'Latest',
+        [switch]$Studio,
+        [switch]$Minimal
+    )
+    $Components = @("Display.Driver", 
+                    "NVI2", 
+                    "EULA.txt", 
+                    "ListDevices.txt", 
+                    "GFExperience/*.txt", 
+                    "GFExperience/locales", 
+                    "GFExperience/EULA.html", 
+                    "GFExperience/PrivacyPolicy", 
+                    "setup.cfg", 
+                    "setup.exe") -join " "
+    if ($Version.ToLower() -eq 'latest') {
+        if ($Studio.IsPresent -eq $true) {$Version = (Get-Driver -Studio)[0]}
+        else {$Version = (Get-Driver)[0]}
+    } 
+    if ($Studio.IsPresent -eq $True) {
+        $Type = "Studio"
+        $DriverLink = "https://international.download.nvidia.com/Windows/$Version/$Version-desktop-win10-win11-64bit-international-nsd-dch-whql.exe" 
+    }
+    else {
+        $Type = "Studio"
+        $DriverLink = "https://international.download.nvidia.com/Windows/$Version/$Version-desktop-win10-win11-64bit-international-dch-whql.exe"
+    }    
+    Write-Output "Checking Download..."
+    try {$StatusCode = (Invoke-WebRequest -Uri "$DriverLink" -DisableKeepAlive -Method Head).StatusCode}
+    catch {$StatusCode = 0}
+    if ($StatusCode -eq 200) {
+        Write-Output "Downloading ($Type - $Version)..."
+        curl.exe -# "$DriverLink" -o "$env:TEMP/$Type - $Version.exe" 
+        if ($Minimal.IsPresent -eq $true) {
+            Write-Output "Looking for (7z.exe)..."
+            $7Zip = @((Get-ChildItem -Path "C:\*7z.exe" -Recurse -Force -ErrorAction 'silentlycontinue').FullName)[0]
+            if ($7Zip -eq @()) {
+                Write-Output 'Please install 7-Zip!'
+            }
+            else {
+                Write-Output "Unpacking driver package with minimal components..."
+                Invoke-Expression """$7Zip"" x -bso0 -bsp1 -bse1 -aoa ""$env:TEMP/$Type - $Version.exe"" $Components -o""$env:TEMP/$Type - $Version"""
+                Write-Output "Unpacked $Type - $Version!"
+                Start-Process "$env:TEMP/$Type - $Version/setup.exe" -ErrorAction 'silentlycontinue'
+            }
+        }
+        else {Start-Process "$env:TEMP/$Type - $Version.exe" -erroraction 'silentlycontinue'}
+    }        
+    else {Write-Output "Version is invaild!"}
+}


### PR DESCRIPTION
1. Rewrite [NVIDIA-Update](https://github.com/lord-carlos/nvidia-update/blob/master/nvidia.ps1) in Python as [NVDDL](https://github.com/aetopia/nvidia-driver-downloader).
> Adds DCH Driver Support + Driver stripping.
2. Ported over the following functions:
> 1. Fetch the latest driver versions for game ready and studio drivers.
> 2. Download studio and game ready drivers + unpacking only the display driver from the driver package.